### PR TITLE
OXDEV-3293 Make paymorrow compatible with shop master

### DIFF
--- a/models/oxpspaymorrowoxuserpayment.php
+++ b/models/oxpspaymorrowoxuserpayment.php
@@ -130,10 +130,9 @@ class OxpsPaymorrowOxUserPayment extends OxpsPaymorrowOxUserPayment_parent
     public function load( $sOxId )
     {
         $sSQL = sprintf(
-            'SELECT `OXID`, `OXUSERID`, `OXPAYMENTSID`, DECODE( `OXVALUE`, "%s" ) AS `OXVALUE`,
+            'SELECT `OXID`, `OXUSERID`, `OXPAYMENTSID`, `OXVALUE`,
               `OXPSPAYMORROWBANKNAME`, `OXPSPAYMORROWIBAN`, `OXPSPAYMORROWBIC`, `OXPSPAYMORROWORDERID`
               FROM `oxuserpayments` WHERE `OXID` = %s',
-            $this->getPaymentKey(),
             oxDb::getDb()->quote( $sOxId )
         );
 

--- a/tests/acceptance/01checkoutWithPaymorrowTest.php
+++ b/tests/acceptance/01checkoutWithPaymorrowTest.php
@@ -46,7 +46,7 @@ class Acceptance_01checkoutWithPaymorrowTest extends PaymorrowAcceptanceTestCase
     /**
      * Prepare shop for testing.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/acceptance/PaymorrowAcceptanceTestCase.php
+++ b/tests/acceptance/PaymorrowAcceptanceTestCase.php
@@ -53,7 +53,7 @@ class PaymorrowAcceptanceTestCase extends OxidEsales\TestingLibrary\AcceptanceTe
     /**
      * Prepare shop for testing.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/components/widgets/oxpspaymorrowinitTest.php
+++ b/tests/unit/module/components/widgets/oxpspaymorrowinitTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Components_OxpsPaymorrowInitTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/controllers/admin/oxpspaymorrowerrorlogTest.php
+++ b/tests/unit/module/controllers/admin/oxpspaymorrowerrorlogTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowAdminErrorLogTest extends OxidTestCas
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/controllers/admin/oxpspaymorrowpaymentmapTest.php
+++ b/tests/unit/module/controllers/admin/oxpspaymorrowpaymentmapTest.php
@@ -56,7 +56,7 @@ class Unit_Module_Controllers_OxpsPaymorrowPaymentMapTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/controllers/oxpspaymorroworderTest.php
+++ b/tests/unit/module/controllers/oxpspaymorroworderTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowOrderTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/controllers/oxpspaymorrowpaymentTest.php
+++ b/tests/unit/module/controllers/oxpspaymorrowpaymentTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowPaymentTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/controllers/oxpspaymorrowprepareorderTest.php
+++ b/tests/unit/module/controllers/oxpspaymorrowprepareorderTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowPrepareOrderTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/controllers/oxpspaymorrowresourceTest.php
+++ b/tests/unit/module/controllers/oxpspaymorrowresourceTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowResourceTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/core/oxpsoxid2paymorrowTest.php
+++ b/tests/unit/module/core/oxpsoxid2paymorrowTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsOxid2PaymorrowTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/core/oxpspaymorrowclientTest.php
+++ b/tests/unit/module/core/oxpspaymorrowclientTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowClientTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/core/oxpspaymorrowerrorhandlerTest.php
+++ b/tests/unit/module/core/oxpspaymorrowerrorhandlerTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowErrorHandlerTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/core/oxpspaymorroweshopdataproviderTest.php
+++ b/tests/unit/module/core/oxpspaymorroweshopdataproviderTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Core_OxpsPaymorrowEshopDataProviderTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/core/oxpspaymorrowgatewayTest.php
+++ b/tests/unit/module/core/oxpspaymorrowgatewayTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Core_OxpsPaymorrowGatewayTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/core/oxpspaymorrowloggerTest.php
+++ b/tests/unit/module/core/oxpspaymorrowloggerTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Core_OxpsPaymorrowLoggerTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -204,8 +204,8 @@ class Unit_Module_Core_OxpsPaymorrowLoggerTest extends OxidTestCase
 
         $sAllLog = $this->SUT->getAllContents();
 
-        $this->assertContains( 'LOG FILE ONE', $sAllLog );
-        $this->assertContains( 'SOME LOG TWO', $sAllLog );
+        $this->assertStringContainsString( 'LOG FILE ONE', $sAllLog );
+        $this->assertStringContainsString( 'SOME LOG TWO', $sAllLog );
 
         unlink( $sPath . 'log1.txt' );
         unlink( $sPath . 'log2.log' );

--- a/tests/unit/module/core/oxpspaymorrowoxviewconfigTest.php
+++ b/tests/unit/module/core/oxpspaymorrowoxviewconfigTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Core_OxpsPaymorrowOxViewConfigTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/core/oxpspaymorrowresourcecacheTest.php
+++ b/tests/unit/module/core/oxpspaymorrowresourcecacheTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Core_OxpsPaymorrowResourceCacheTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class Unit_Module_Core_OxpsPaymorrowResourceCacheTest extends OxidTestCase
     /**
      * Clean up state after test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $sTempFolder = oxRegistry::getConfig()->getConfigParam( 'sCompileDir' ) . DIRECTORY_SEPARATOR . 'test_media';
 

--- a/tests/unit/module/core/oxpspaymorrowresponsehandlerTest.php
+++ b/tests/unit/module/core/oxpspaymorrowresponsehandlerTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowResponseHandlerTest extends OxidTestC
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/core/oxpspaymorrowsettingsTest.php
+++ b/tests/unit/module/core/oxpspaymorrowsettingsTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Controllers_OxpsPaymorrowSettingsTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/models/oxpspaymorrowoxbasketTest.php
+++ b/tests/unit/module/models/oxpspaymorrowoxbasketTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Models_OxpsPaymorrowOxBasketTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/models/oxpspaymorrowoxbasketitemTest.php
+++ b/tests/unit/module/models/oxpspaymorrowoxbasketitemTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Models_OxpsPaymorrowOxBasketItemTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/models/oxpspaymorrowoxorderTest.php
+++ b/tests/unit/module/models/oxpspaymorrowoxorderTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Models_OxpsPaymorrowOxOrderTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/models/oxpspaymorrowoxpaymentTest.php
+++ b/tests/unit/module/models/oxpspaymorrowoxpaymentTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Models_OxpsPaymorrowOxPaymentTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/models/oxpspaymorrowoxpaymentgatewayTest.php
+++ b/tests/unit/module/models/oxpspaymorrowoxpaymentgatewayTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Models_OxpsPaymorrowOxPaymentGatewayTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/models/oxpspaymorrowoxuserTest.php
+++ b/tests/unit/module/models/oxpspaymorrowoxuserTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Models_OxpsPaymorrowOxUserTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/module/models/oxpspaymorrowoxuserpaymentTest.php
+++ b/tests/unit/module/models/oxpspaymorrowoxuserpaymentTest.php
@@ -49,7 +49,7 @@ class Unit_Module_Models_OxpsPaymorrowOxUserPaymentTest extends OxidTestCase
      *
      * @return null|void
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Hi, I provided some changes which are needed in order the test to finish with success for master shop. Changes are needed because:
- master shop uses phpunit ^9 and **setUp** and **tearDown** methods should be compatible with their parents
- Database encoding was completely removed and **getPaymentKey** method was removed